### PR TITLE
I've aligned the plugin with the README Next Steps and applied packag…

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-recursive-include src/octoprint_printauth/static *
-recursive-include src/octoprint_printauth/templates *
+recursive-include authplugin/static *
+recursive-include authplugin/templates *

--- a/authplugin/__init__.py
+++ b/authplugin/__init__.py
@@ -184,6 +184,7 @@ class PrintAuthPlugin(
 
 # --- Plugin Registration ---
 __plugin_name__ = "Print Authentication Plugin" # Changed name back
+__plugin_version__ = "1.0.0"
 __plugin_pythoncompat__ = ">=3.7,<4"
 __plugin_identifier__ = "print_auth_plugin" # Define identifier explicitly here too
 

--- a/authplugin/templates/plugin_print_auth_plugin_settings.jinja2
+++ b/authplugin/templates/plugin_print_auth_plugin_settings.jinja2
@@ -1,0 +1,78 @@
+<div id="settings_plugin_print_auth_plugin" class="settings_plugin">
+    <div class="row-fluid">
+        <div class="span6">
+            <fieldset>
+                <legend>PrintAuth Plugin Settings</legend>
+
+                <div class="control-group">
+                    <label class="control-label" for="print_auth_login_url">Login URL</label>
+                    <div class="controls">
+                        <input type="text" id="print_auth_login_url" class="input-block-level" data-bind="value: settings.plugins.print_auth_plugin.login_url()">
+                    </div>
+                </div>
+
+                <div class="control-group">
+                    <label class="control-label" for="print_auth_username">Username</label>
+                    <div class="controls">
+                        <input type="text" id="print_auth_username" class="input-block-level" data-bind="value: settings.plugins.print_auth_plugin.username()">
+                    </div>
+                </div>
+
+                <div class="control-group">
+                    <label class="control-label" for="print_auth_password">Password</label>
+                    <div class="controls">
+                        <input type="password" id="print_auth_password" class="input-block-level" data-bind="value: settings.plugins.print_auth_plugin.password()">
+                    </div>
+                </div>
+
+                <div class="control-group">
+                    <label class="control-label" for="print_auth_api_url">API URL</label>
+                    <div class="controls">
+                        <input type="text" id="print_auth_api_url" class="input-block-level" data-bind="value: settings.plugins.print_auth_plugin.api_url()">
+                    </div>
+                </div>
+
+                <div class="control-group">
+                    <label class="control-label" for="print_auth_permission_id">Permission ID (Optional)</label>
+                    <div class="controls">
+                        <input type="text" id="print_auth_permission_id" class="input-block-level" data-bind="value: settings.plugins.print_auth_plugin.permission_id()" placeholder="e.g., CanPrintOnPrinterX">
+                        <span class="help-block">Specify if a specific permission ID is required by your authentication system.</span>
+                    </div>
+                </div>
+
+                <div class="control-group">
+                    <label class="control-label" for="print_auth_workstation_id">Workstation ID (Optional)</label>
+                    <div class="controls">
+                        <input type="text" id="print_auth_workstation_id" class="input-block-level" data-bind="value: settings.plugins.print_auth_plugin.workstation_id()" placeholder="e.g., PrintStation01">
+                        <span class="help-block">Identifier for the workstation or printer, if needed by the auth system.</span>
+                    </div>
+                </div>
+
+            </fieldset>
+        </div>
+        <div class="span6">
+            <fieldset>
+                <legend>Information</legend>
+                <p>
+                    This plugin integrates with an external authentication server to authorize print jobs.
+                    Configure the necessary URLs and credentials to connect to your authentication provider.
+                </p>
+                <p>
+                    <strong>Login URL:</strong> The endpoint for user authentication.
+                </p>
+                <p>
+                    <strong>Username/Password:</strong> Credentials for the service/user that OctoPrint will use to interact with the auth system (if applicable).
+                </p>
+                <p>
+                    <strong>API URL:</strong> The base URL for any API calls the plugin needs to make to the authentication server (e.g., to verify permissions).
+                </p>
+                <p>
+                    <strong>Permission ID:</strong> If your authentication system uses specific permission identifiers for printing, enter it here.
+                </p>
+                <p>
+                    <strong>Workstation ID:</strong> If your authentication system needs to identify the printer/workstation, enter its ID here.
+                </p>
+            </fieldset>
+        </div>
+    </div>
+</div>

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(
-    name="OctoPrint-AuthPluginTest", # Changed name slightly to reflect test
+    name="OctoPrint-PrintAuth", # Changed name slightly to reflect test
     version="1.0.0",
     packages=find_packages(), # Correct: Finds 'authplugin' now
     install_requires=[


### PR DESCRIPTION
…ing fixes.

Here's what I did:
- Updated the settings template name and its initial content.
- Standardized the plugin distribution name to OctoPrint-PrintAuth.
- Added `__plugin_version__` to `__init__.py`.
- Corrected `MANIFEST.in` to include files from the 'authplugin' directory.

These changes address items from the README's 'Next Steps (Development)' and prepare the plugin for more robust packaging.